### PR TITLE
Jacoco sonar

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -3,7 +3,7 @@ name: Fantasy Sport API Pipeline
 on: [ push ]
 
 jobs:
-  build:
+  test-and-sonar:
     runs-on: ubuntu-latest
 
     steps:
@@ -32,6 +32,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./gradlew build sonarqube --info
+        run: ./gradlew jacocoTestReport sonarqube -x test --info
       - name: Acceptance tests
         run: ./gradlew acceptanceTest

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -12,9 +12,26 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 15
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - name: Cache Gradle packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
       - name: Unit tests
         run: ./gradlew unitTest
       - name: Integration tests
         run: ./gradlew integrationTest
+      - name: Sonarqube
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./gradlew build sonarqube --info
       - name: Acceptance tests
         run: ./gradlew acceptanceTest

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,8 @@ plugins {
     id 'io.spring.dependency-management' version '1.0.10.RELEASE'
     id 'java'
     id 'com.adarshr.test-logger' version '2.1.1'
+    id 'jacoco'
+    id 'org.sonarqube' version '3.0'
 }
 
 group = 'io.henriquels25'
@@ -56,4 +58,24 @@ task acceptanceTest(type: Test) {
 
 testlogger {
     showSimpleNames true
+}
+
+jacocoTestReport {
+    sourceSets sourceSets.main
+    getExecutionData().setFrom(fileTree(buildDir).include("/jacoco/*.exec"))
+    reports {
+        xml.enabled true
+    }
+}
+
+jacoco {
+    toolVersion = "0.8.6"
+}
+
+sonarqube {
+    properties {
+        property "sonar.projectKey", "henriquels25_fantasy-sport-api"
+        property "sonar.organization", "henriquels"
+        property "sonar.host.url", "https://sonarcloud.io"
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -77,5 +77,6 @@ sonarqube {
         property "sonar.projectKey", "henriquels25_fantasy-sport-api"
         property "sonar.organization", "henriquels"
         property "sonar.host.url", "https://sonarcloud.io"
+        property "sonar.exclusions", "**/FantasySportApiApplication.java"
     }
 }

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,1 @@
+lombok.addLombokGeneratedAnnotation = true

--- a/src/main/java/io/henriquels25/fantasysport/player/infra/controller/PlayerController.java
+++ b/src/main/java/io/henriquels25/fantasysport/player/infra/controller/PlayerController.java
@@ -16,7 +16,7 @@ class PlayerController {
     private final PlayerFacade playerFacade;
 
     @GetMapping
-    Flux<Player> allPlayers() {
+    public Flux<Player> allPlayers() {
         return playerFacade.allPlayers();
     }
 


### PR DESCRIPTION
Fixes #10 

- [x] - Configure Jacoco plugin;
- [x] - Configure SonarQube plugin;
- [x] - Coverage of unit and integration test tasks are combined to be sent to Sonar;
- [x] - Configure execution of Sonar analysis in the pipeline (GitHub actions).